### PR TITLE
Add extra `requestThoughts()` calls from the watch

### DIFF
--- a/JotDownWatch Watch App/Views/ContentView.swift
+++ b/JotDownWatch Watch App/Views/ContentView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct ContentView: View {
     
+    @ObservedObject private var session = WatchSessionManager.shared
+    
     var body: some View {
         NavigationStack {
             VStack() {
@@ -43,6 +45,9 @@ struct ContentView: View {
                 }
                 
             }.padding()
+                
+        }.onAppear {
+            session.requestThoughts()
         }
     }
 }

--- a/JotDownWatch Watch App/Views/WatchThoughtsEntryView.swift
+++ b/JotDownWatch Watch App/Views/WatchThoughtsEntryView.swift
@@ -43,6 +43,7 @@ struct WatchThoughtsEntryView: View {
                     
                     Button("Add") {
                         session.sendThought(thoughtInput)
+                        session.requestThoughts()
                         dismiss()
                     }
                     .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Description
After doing some testing, I've added two calls for the watch to `requestThoughts()` from the phone. The watch will now do this when the app is opened and immediately after sending a thought to the phone. This will improve the thoughts list on the watch end and decrease delays in syncing. 

<!-- Link any related issues using #issue_number -->
Fixes #94 
Related to #36 

