### PR TITLE
migrate to @Observable and resolve error in view title

### DIFF
--- a/JotDownWatch Watch App/ViewModels/WatchSessionManager.swift
+++ b/JotDownWatch Watch App/ViewModels/WatchSessionManager.swift
@@ -8,11 +8,11 @@
 import WatchConnectivity
 import Combine
 
-class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
+@Observable class WatchSessionManager: NSObject, WCSessionDelegate {
     static let shared = WatchSessionManager()
     
-    @Published var thoughts: [[String: Any]] = []
-    @Published var searchResults: [[String: Any]] = []
+    var thoughts: [[String: Any]] = []
+    var searchResults: [[String: Any]] = []
     
     override init() {
         super.init()

--- a/JotDownWatch Watch App/Views/ContentView.swift
+++ b/JotDownWatch Watch App/Views/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct ContentView: View {
     
-    @ObservedObject private var session = WatchSessionManager.shared
+    private var session = WatchSessionManager.shared
     
     var body: some View {
         NavigationStack {
@@ -46,7 +46,8 @@ struct ContentView: View {
                 
             }.padding()
                 
-        }.onAppear {
+        }
+        .onAppear {
             session.requestThoughts()
         }
     }

--- a/JotDownWatch Watch App/Views/WatchSearchView.swift
+++ b/JotDownWatch Watch App/Views/WatchSearchView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct WatchSearchView: View {
     
-    @ObservedObject private var session = WatchSessionManager.shared
+    private var session = WatchSessionManager.shared
     @State private var searchInput: String = ""
     @State private var showResults = false
     

--- a/JotDownWatch Watch App/Views/WatchThoughtsEntryView.swift
+++ b/JotDownWatch Watch App/Views/WatchThoughtsEntryView.swift
@@ -12,7 +12,7 @@ struct WatchThoughtsEntryView: View {
 
     @State private var thoughtInput: String = ""
     @State private var characterLimit: Int = 250
-    @ObservedObject private var session = WatchSessionManager.shared
+    private var session = WatchSessionManager.shared
     @Environment(\.dismiss) private var dismiss
     
     func calculateColor() -> Color {

--- a/JotDownWatch Watch App/Views/WatchThoughtsListView.swift
+++ b/JotDownWatch Watch App/Views/WatchThoughtsListView.swift
@@ -9,9 +9,11 @@ import SwiftData
 import SwiftUI
 
 struct WatchThoughtsListView: View {
-    
-    @ObservedObject private var watchSession = WatchSessionManager.shared
-    var title: String = ""
+    private var watchSession = WatchSessionManager.shared
+    var title: String
+    init(title: String) {
+        self.title = title
+    }
     var dataSource: [[String: Any]] {
         if title == "Thoughts" {
             return watchSession.thoughts
@@ -54,5 +56,6 @@ struct WatchThoughtsListView: View {
 }
 
 #Preview {
-    WatchThoughtsListView()
+    WatchThoughtsListView(title: "Thoughts")
 }
+


### PR DESCRIPTION
Migrated from using @ObservedObject in the Apple Watch app to using @Observable macro. Carried out changes across watch app. Whenever I made this change, the title variable for one of the view was not happy, so made a more explicit setting of the variable.
